### PR TITLE
fix incorrect format parameter

### DIFF
--- a/dnstop.c
+++ b/dnstop.c
@@ -1162,7 +1162,7 @@ qtype_str(unsigned int t)
     default:
 	if (qtypes_buf[t])
 	    return qtypes_buf[t];
-	snprintf(buf, sizeof(buf), "#%hu?", t);
+	snprintf(buf, sizeof(buf), "#%u?", t);
 	return qtypes_buf[t] = strdup(buf);
     }
     /* NOTREACHED */


### PR DESCRIPTION
fixes the following compiler warning:

```
clang -g -O2 -DUSE_IPV6=1   -c -o dnstop.o dnstop.c
dnstop.c:1165:38: warning: format specifies type 'unsigned short' but the argument has type 'unsigned int' [-Wformat]
        snprintf(buf, sizeof(buf), "#%hu?", t);
                                     ~~~    ^
                                     %u                                                                                                             
1 warning generated.
```