### PR TITLE
Add servfail filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ To help find especially undesirable DNS queries, _dnstop_ provides a number of f
 - For unknown/invalid TLDs
 - A queries where the query name is already an IP address
 - PTR queries for RFC1918 address space
-- Responses with code REFUSED 
+- Responses with code REFUSED
+- Responses with code SERVFAIL
 
 _dnstop_ can either read packets from the live capture device, or from a tcpdump savefile.
 

--- a/dnstop.8
+++ b/dnstop.8
@@ -93,6 +93,12 @@ option, tells
 .Nm
 to count only replies with rcode REFUSED.
 .Pp
+The "servfail" filter, when used with the
+.Fl R
+option, tells
+.Nm
+to count only replies with rcode SERVFAIL.
+.Pp
 The "qtype-any" filter tells
 .Nm
 to count only message of type ANY.

--- a/dnstop.c
+++ b/dnstop.c
@@ -230,6 +230,7 @@ Filter_t UnknownTldFilter;
 Filter_t AforAFilter;
 Filter_t RFC1918PtrFilter;
 Filter_t RcodeRefusedFilter;
+Filter_t RcodeServfailFilter;
 Filter_t QnameFilter;
 Filter_t BitsquatFilter;
 Filter_t QtypeAnyFilter;
@@ -1649,6 +1650,12 @@ RcodeRefusedFilter(FilterData * fd)
 }
 
 int
+RcodeServfailFilter(FilterData * fd)
+{
+    return SERVFAIL == fd->rcode ? 1 : 0;
+}
+
+int
 QnameFilter(FilterData * fd)
 {
     const char *F = opt_filter_by_name;
@@ -1732,6 +1739,8 @@ set_filter(const char *fn)
 	Filter = RFC1918PtrFilter;
     else if (0 == strcmp(fn, "refused"))
 	Filter = RcodeRefusedFilter;
+    else if (0 == strcmp(fn, "servfail"))
+	Filter = RcodeServfailFilter;
     else if (0 == strcmp(fn, "qname"))
 	Filter = QnameFilter;
     else if (0 == strcmp(fn, "bitsquat"))
@@ -1814,6 +1823,7 @@ usage(void)
     fprintf(stderr, "\tA-for-A\n");
     fprintf(stderr, "\trfc1918-ptr\n");
     fprintf(stderr, "\trefused\n");
+    fprintf(stderr, "\tservfail\n");
     fprintf(stderr, "\tqtype-any\n");
     exit(1);
 }
@@ -1955,7 +1965,7 @@ main(int argc, char *argv[])
     if (0 == opt_count_ipv4 && 0 == opt_count_ipv6)
 	opt_count_ipv4 = opt_count_ipv6 = 1;
 
-    if (RcodeRefusedFilter == Filter) {
+    if (RcodeRefusedFilter == Filter || RcodeServfailFilter == Filter) {
 	opt_count_queries = 0;
 	opt_count_replies = 1;
     }


### PR DESCRIPTION
Similar to REFUSED responses, SERVFAILs represent an interesting subset that can be useful to filter on while debugging DNS servers.