### PR TITLE
Add nxdomain filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To help find especially undesirable DNS queries, _dnstop_ provides a number of f
 - PTR queries for RFC1918 address space
 - Responses with code REFUSED
 - Responses with code SERVFAIL
+- Responses with code NXDOMAIN
 
 _dnstop_ can either read packets from the live capture device, or from a tcpdump savefile.
 

--- a/dnstop.8
+++ b/dnstop.8
@@ -1,5 +1,5 @@
 .\" $Id$
-.\" 
+.\"
 .\" manpage written by jose@monkey.org
 .\"
 .Dd 21 March, 2008
@@ -24,7 +24,7 @@ is a small tool to listen on
 or to parse the file
 .Ar savefile
 and collect and print statistics on the local network's DNS traffic. You
-must have read access to 
+must have read access to
 .Pa /dev/bpf\&* .
 .Sh COMMAND LINE OPTIONS
 .Pp
@@ -65,7 +65,7 @@ provides more details, but also requires more memory and CPU.
 .It Fl f
 input filter name
 .Pp
-The "unknown-tlds" filter 
+The "unknown-tlds" filter
 includes only queries for TLDs that are
 bogus.  Useful for identifying hosts/servers
 that leak queries for things like "localhost"
@@ -99,6 +99,12 @@ option, tells
 .Nm
 to count only replies with rcode SERVFAIL.
 .Pp
+The "nxdomain" filter, when used with the
+.Fl R
+option, tells
+.Nm
+to count only replies with rcode NXDOMAIN.
+.Pp
 The "qtype-any" filter tells
 .Nm
 to count only message of type ANY.
@@ -116,7 +122,7 @@ hash table buckets.
 Do not tabulate the sources + query name counters.  This can significantly
 reduce memory usage on busy servers and large savefiles.
 .It Ar savefile
-a captured network trace in 
+a captured network trace in
 .Cm pcap
 format
 .It Ar device
@@ -128,7 +134,7 @@ While running, the following options are available to alter the display:
 .Bl -tag -width Ds
 .It s
 display the source address table
-.It d 
+.It d
 display the destination address table
 .It t
 display the breakdown of query types seen
@@ -181,7 +187,7 @@ redraw
 .It ?
 help
 .El
-.Pp 
+.Pp
 .Sh NON-INTERACTIVE MODE
 If stdout is not a tty,
 .Nm
@@ -215,7 +221,7 @@ you might want to examine both queries and replies by giving both
 .Fl R
 and
 .Fl Q
-command line options.  In this case, only the response code counts 
+command line options.  In this case, only the response code counts
 are taken from the replies and all other attributes
 are taken from the queries.
 .Pp


### PR DESCRIPTION
Similar to my previous pull request, being able to filter and see stats for queries that result in NXDOMAIN from a recursive resolver can help identify misconfigured upstreams and/or downstreams. 

It also looks like my IDE went ahead and wiped some trailing whitespace along the way. Let me know if that's a problem and I can slim down the commit to only the relevant changes.