### PR TITLE
Fix broken man by adding directory creation statement in install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -55,6 +55,7 @@ tar:
 
 install: $(PROG)
 	install -m 755 $(PROG) ${DESTDIR}${bindir}
+	mkdir -p ${DESTDIR}${mandir}/man8
 	install -m 644 $(PROG).8 ${DESTDIR}${mandir}/man8
 
 uninstall:


### PR DESCRIPTION
very small contribution to fix man issue
added a directory creation statement in the install section of Makefile.in

In Ubuntu and OSX, /usr/local/share/man/man8 does not necessarily exist
CentOS seems to be creating the subfolders upfront

From a fresh CentOS 

```
# ls /usr/local/share/man/
man1  man1x  man2  man2x  man3	man3x  man4  man4x  man5  man5x  man6  man6x  man7  man7x  man8  man8x	man9  man9x  mann

```

OSX

```
% ls /usr/local/share/man
de	es	fr	hr	hu	it	ja	man1	pl	pt_BR	pt_PT	ro	ru	sk	zh
```



